### PR TITLE
[FEATURE] to_csv : product_list view 추가 (pagination 24)

### DIFF
--- a/iherb/to_csv/urls.py
+++ b/iherb/to_csv/urls.py
@@ -1,10 +1,12 @@
 from django.urls import path
 from .views import (
     CrawlingView,
-    OneCrawlingView
+    OneCrawlingView,
+    BathPersonalProductListView
 )
 
 urlpatterns = [
     path('/crawling', CrawlingView.as_view()),
-    path('/one_crawling', OneCrawlingView.as_view())
+    path('/one_crawling', OneCrawlingView.as_view()),
+    path('/product', BathPersonalProductListView.as_view())
 ]

--- a/iherb/to_csv/views.py
+++ b/iherb/to_csv/views.py
@@ -4,6 +4,14 @@ import csv
 
 from django.views import View
 from django.http import JsonResponse
+from django.core.paginator import (
+    Paginator,
+    EmptyPage
+)
+
+from to_csv.models import (
+    BathPersonalProduct
+)
 
 
 class OneCrawlingView(View):
@@ -35,11 +43,12 @@ class OneCrawlingView(View):
 
                 product_id = a_tag[0].get(
                     'data-ga-product-id') if a_tag[0].get('data-ga-product-id') != None else ''
+
                 img_src = a_tag[0].get('href') if a_tag[0].get(
                     'href') != None else ''
+
                 name = a_tag[0].get(
                     'aria-label') if a_tag[0].get('aria-label') != None else ''
-                print(name)
 
                 if len(a_tag) >= 2:
                     rating = a_tag[2].get('title').split(' - ')[0]
@@ -51,6 +60,7 @@ class OneCrawlingView(View):
 
                 price = a_tag[0].get(
                     'data-ga-discount-price') if a_tag[0].get('data-ga-discount-price') != None else ''
+
                 link = a_tag[0].get('href') if a_tag[0].get(
                     'href') != None else ''
 
@@ -145,3 +155,41 @@ class CrawlingView(View):
 
         except ValueError as value_e:
             return JsonResponse({'ValueError': str(value_e)}, status=400)
+
+
+class BathPersonalProductListView(View):
+    def get(self, request):
+        try:
+            page = request.GET.get('page')
+            products_list = BathPersonalProduct.objects.all()
+
+            p = Paginator(products_list, 24)
+            p_products = p.page(page)
+
+            result = list({
+                'key_number': product.key_number,
+                'img_src': product.img_src,
+                'name': product.name,
+                'rating': product.rating,
+                'reviews': product.reviews,
+                'price': product.price,
+                'link': product.link
+            } for product in p_products)
+
+            return JsonResponse({
+                'pages': p.num_pages,
+                'items': p.count,
+                'products_list_per_page': result
+            }, status=200)
+
+        except TypeError as type_e:
+            return JsonResponse({'TypeError': str(type_e)}, status=400)
+
+        except KeyError as key_e:
+            return JsonResponse({'KeyError': key_e}, status=400)
+
+        except ValueError as value_e:
+            return JsonResponse({'ValueError': str(value_e)}, status=400)
+
+        except EmptyPage as page_e:
+            return JsonResponse({'EmptyPage': str(page_e)}, status=400)


### PR DESCRIPTION
# Contents
- ProductListView 추가

# Detail of contents
- crawling 후 DB에 넣은 내용을 뿌려주는 list API 추가
- method : GET
- response 구성 : 전체 페이지 수, 전체 아이템 수, 해당 페이지 내 상품 리스트 구성 항목(상품 고유 id number, img_src, name, rating, reviews, price, 상세 페이지 link)  
- 실제 홈페이지와 같이 페이지당 24개의 상품에 대한 정보를 내려주도록 구성

# Test 
![스크린샷 2021-06-01 오전 12 15 04](https://user-images.githubusercontent.com/59601700/120213662-6b75b780-c26e-11eb-962b-4038357adba0.png)

# To-do
- 217 페이지에 걸쳐 5200 여개의 상품에 대한 정보 크롤링이 가능하나, 응답시간이 10분을 넘어가는 문제가 있음
- 성능 최적화에 대해서 연구해 볼 것
- 연구 시 reference : https://docs.python.org/ko/3/library/multiprocessing.html
- 이후 main 머지할 것